### PR TITLE
Update documentation for join command flag

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -48,7 +48,7 @@ Description: If this node is part of a raft replication cluster, then this flag 
 
 Flag: `--join-addr`<br/>
 Type: `string`<br/>
-Description: When adding a node to a replication cluster, this is the address and port of any cluster member. The current node will use this to request permission to join the cluster. The format of this flag is `<ip-address>:<discovery-port>`.
+Description: When adding a node to a replication cluster, this is the address and port of any cluster member. The current node will use this to request permission to join the cluster. The format of this flag is `<target-server-id>/<target-ip>:<target-port>`.
 
 Flag: `--discovery-port`<br/>
 Type: `integer`<br/>


### PR DESCRIPTION
Update `--join-addr` flag parameter format to `<target-server-id>/<target-ip>:<target-port>` per #142 