### PR TITLE
Add missing commands in the docs + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Benchmark script options:
 <a name="commands-connection"></a>
 ## CONNECTION
 * [AUTH](https://sugardb.io/docs/commands/connection/auth)
+* [ECHO](https://sugardb.io/docs/commands/connection/echo)
 * [HELLO](https://sugardb.io/docs/commands/connection/hello)
 * [PING](https://sugardb.io/docs/commands/connection/ping)
 * [SELECT](https://sugardb.io/docs/commands/connection/select)
@@ -204,6 +205,7 @@ Benchmark script options:
 
 <a name="commands-generic"></a>
 ## GENERIC
+* [COPY](https://sugardb.io/docs/commands/generic/copy)
 * [DECR](https://sugardb.io/docs/commands/generic/decr)
 * [DECRBY](https://sugardb.io/docs/commands/generic/decrby)
 * [DEL](https://sugardb.io/docs/commands/generic/del)
@@ -216,8 +218,9 @@ Benchmark script options:
 * [GETEX](https://sugardb.io/docs/commands/generic/get)
 * [INCR](https://sugardb.io/docs/commands/generic/incr)
 * [INCRBY](https://sugardb.io/docs/commands/generic/incrby)
+* [INCRBYFLOAT](https://sugardb.io/docs/commands/generic/incrbyfloat)
 * [MGET](https://sugardb.io/docs/commands/generic/mget)
-* [MOVE](https://sugardb.io/docs/commands/generic/move) //-----CHECCKKKKKKKKKK
+* [MOVE](https://sugardb.io/docs/commands/generic/move)
 * [MSET](https://sugardb.io/docs/commands/generic/mset)
 * [OBJECTFREQ](https://sugardb.io/docs/commands/generic/objectfreq)
 * [OBJECTIDLETIME](https://sugardb.io/docs/commands/generic/objectidletime)
@@ -226,6 +229,7 @@ Benchmark script options:
 * [PEXPIREAT](https://sugardb.io/docs/commands/generic/pexpireat)
 * [PEXPIRETIME](https://sugardb.io/docs/commands/generic/pexpiretime)
 * [PTTL](https://sugardb.io/docs/commands/generic/pttl)
+* [RANDOMKEY](https://sugardb.io/docs/commands/generic/randomkey)
 * [RENAME](https://sugardb.io/docs/commands/generic/rename)
 * [SET](https://sugardb.io/docs/commands/generic/set)
 * [TTL](https://sugardb.io/docs/commands/generic/ttl)
@@ -325,6 +329,7 @@ Benchmark script options:
 
 <a name="commands-string"></a>
 ## STRING
+* [APPEND](https://sugardb.io/docs/commands/string/append)
 * [GETRANGE](https://sugardb.io/docs/commands/string/getrange)
 * [SETRANGE](https://sugardb.io/docs/commands/string/setrange)
 * [STRLEN](https://sugardb.io/docs/commands/string/strlen)

--- a/README.md
+++ b/README.md
@@ -226,12 +226,18 @@ MSET (10 keys): 56022.41 requests per second, p50=0.463 msec
 * [FLUSHALL](https://sugardb.io/docs/commands/generic/flushall)
 * [FLUSHDB](https://sugardb.io/docs/commands/generic/flushdb)
 * [GET](https://sugardb.io/docs/commands/generic/get)
+* [GETDEL](https://sugardb.io/docs/commands/generic/getdel)
+* [GETEX](https://sugardb.io/docs/commands/generic/get)
 * [INCR](https://sugardb.io/docs/commands/generic/incr)
 * [INCRBY](https://sugardb.io/docs/commands/generic/incrby)
 * [MGET](https://sugardb.io/docs/commands/generic/mget)
+* [MOVE](https://sugardb.io/docs/commands/generic/move) //-----CHECCKKKKKKKKKK
 * [MSET](https://sugardb.io/docs/commands/generic/mset)
+* [OBJECTFREQ](https://sugardb.io/docs/commands/generic/objectfreq)
+* [OBJECTIDLETIME](https://sugardb.io/docs/commands/generic/objectidletime)
 * [PERSIST](https://sugardb.io/docs/commands/generic/persist)
 * [PEXPIRE](https://sugardb.io/docs/commands/generic/pexpire)
+* [PEXPIREAT](https://sugardb.io/docs/commands/generic/pexpireat)
 * [PEXPIRETIME](https://sugardb.io/docs/commands/generic/pexpiretime)
 * [PTTL](https://sugardb.io/docs/commands/generic/pttl)
 * [RENAME](https://sugardb.io/docs/commands/generic/rename)
@@ -337,7 +343,3 @@ MSET (10 keys): 56022.41 requests per second, p50=0.463 msec
 * [SETRANGE](https://sugardb.io/docs/commands/string/setrange)
 * [STRLEN](https://sugardb.io/docs/commands/string/strlen)
 * [SUBSTR](https://sugardb.io/docs/commands/string/substr)
-
-
-
-

--- a/docs/docs/commands/connection/echo.mdx
+++ b/docs/docs/commands/connection/echo.mdx
@@ -1,0 +1,43 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# ECHO
+
+### Syntax
+```
+ECHO [message]
+```
+
+### Module
+<span className="acl-category">connection</span>
+
+### Categories
+<span className="acl-category">connection</span>
+<span className="acl-category">fast</span>
+
+### Description
+Sends a message to the SugarDB server and it returns the same message back.
+
+### Examples
+
+<Tabs
+  defaultValue="go"
+  values={[
+    { label: 'Go (Embedded)', value: 'go', },
+    { label: 'CLI', value: 'cli', },
+  ]}
+>
+  <TabItem value="go">
+    ```go
+    // Not available in embedded mode.
+    ```
+  </TabItem>
+  <TabItem value="cli">
+  ```
+  Echo with message:
+  ```
+  > ECHO "Hello, world!"
+  "Hello, world!"
+  ```
+  </TabItem>
+</Tabs>

--- a/docs/docs/commands/connection/echo.mdx
+++ b/docs/docs/commands/connection/echo.mdx
@@ -33,11 +33,10 @@ Sends a message to the SugarDB server and it returns the same message back.
     ```
   </TabItem>
   <TabItem value="cli">
-  ```
   Echo with message:
-  ```
-  > ECHO "Hello, world!"
-  "Hello, world!"
-  ```
+
+    ```
+    > ECHO "Hello, World!"
+    ```
   </TabItem>
 </Tabs>

--- a/docs/docs/commands/generic/copy.mdx
+++ b/docs/docs/commands/generic/copy.mdx
@@ -1,0 +1,85 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# COPY
+
+### Syntax
+```
+COPY source destination [DB destination-db] [REPLACE]
+```
+
+### Module
+<span className="acl-category">generic</span>
+
+### Categories 
+<span className="acl-category">slow</span>
+<span className="acl-category">write</span>
+<span className="acl-category">keyspace</span>
+
+### Description
+Copies the value stored at the source key to the destination key. 
+Returns 1 if copied and 0 if not copied. 
+Also returns 0 if the destination key already exists in the database and the REPLACE option is not set. 
+
+### Options 
+- `DB destination-db`: the destination database to copy the key to
+- `REPLACE`: replace the destination key if it already exists
+
+### Examples
+
+<Tabs
+  defaultValue="go"
+  values={[
+    { label: 'Go (Embedded)', value: 'go', },
+    { label: 'CLI', value: 'cli', },
+  ]}
+>
+  <TabItem value="go">
+  The API provides a struct called COPYOptions that wraps these options in a convenient object.
+   ```go
+        type COPYOptions struct {        
+            Database string
+	          Replace  bool
+        }
+        ```
+
+  Copy the value stored at key 'hello' to the new key 'bye'
+  ```go
+  db, err := sugardb.NewSugarDB()
+  if err != nil {
+    log.Fatal(err)
+  }
+  db.Set("hello", "world")
+  key = db.Copy("hello", "bye")
+  ```
+
+  Copy the value stored at key 'hello' in database 0 and replace the value at key 'bye' in database 1
+  ```go
+  db, err := sugardb.NewSugarDB()
+  if err != nil {
+    log.Fatal(err)
+  }
+  err := db.SelectDB(1)
+  ok, err := db.Set("bye", "goodbye")
+  err := db.SelectDB(0)
+  ok, err := db.Set("hello", "world")
+  ret, err = db.Copy("hello", "bye", db.COPYOptions{Database: "1", Replace: true})
+  ```
+  </TabItem>
+  <TabItem value="cli">
+  Copy the value stored at key 'hello' to the key 'bye'
+  ```
+  > SET "hello" "world"
+  > COPY "hello" "bye"
+  ```
+
+  Copy the value stored at key 'hello' in database 0 and replace the value at key 'bye' in database 1
+  ```
+  > SELECT 1
+  > SET "bye" "goodbye"
+  > SELECT 0
+  > SET "hello" "world"
+  > COPY "hello" "bye" DB 1 REPLACE
+  ```
+  </TabItem>
+</Tabs> 

--- a/docs/docs/commands/generic/incrbyfloat.mdx
+++ b/docs/docs/commands/generic/incrbyfloat.mdx
@@ -1,0 +1,50 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# INCRBYFLOAT
+
+### Syntax
+```
+INCRBYFLOAT key increment
+```
+
+### Module
+<span className="acl-category">generic</span>
+
+### Categories 
+<span className="acl-category">fast</span>
+<span className="acl-category">write</span>
+
+### Description
+Increments the floating point number stored at key by increment. If the key does not exist, it is set to 0 before performing
+the operation. An error is returned if the key contains a value of the wrong type or contains a string
+that can not be represented as a floating point number.
+
+### Options
+
+### Examples
+
+<Tabs
+  defaultValue="go"
+  values={[
+    { label: 'Go (Embedded)', value: 'go', },
+    { label: 'CLI', value: 'cli', },
+  ]}
+>
+  <TabItem value="go">
+  Increment the value of the key `mykey` by 10.33:
+  ```go
+  db, err := sugardb.NewSugarDB()
+  if err != nil {
+    log.Fatal(err)
+  }
+  value, err := db.IncrByFloat("mykey", "10.33")
+  ```
+  </TabItem>
+  <TabItem value="cli">
+  Increment the value of the key `mykey` by 10.33:
+  ```
+  > INCRBYFLOAT mykey 10.33
+  ```
+  </TabItem>
+</Tabs> 

--- a/docs/docs/commands/generic/randomkey.mdx
+++ b/docs/docs/commands/generic/randomkey.mdx
@@ -1,0 +1,47 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# RANDOMKEY
+
+### Syntax
+```
+RANDOMKEY
+```
+
+### Module
+<span className="acl-category">generic</span>
+
+### Categories 
+<span className="acl-category">slow</span>
+<span className="acl-category">read</span>
+<span className="acl-category">keyspace</span>
+
+### Description
+Returns a random key from the currently selected database. If no keys are available, an empty string is returned.
+
+### Examples
+
+<Tabs
+  defaultValue="go"
+  values={[
+    { label: 'Go (Embedded)', value: 'go', },
+    { label: 'CLI', value: 'cli', },
+  ]}
+>
+  <TabItem value="go">
+  Get a random key from the database:
+  ```go
+  db, err := sugardb.NewSugarDB()
+  if err != nil {
+    log.Fatal(err)
+  }
+  key, err := db.RandomKey()
+  ```
+  </TabItem>
+  <TabItem value="cli">
+  Get a random key from the database:
+  ```
+  > RANDOMKEY
+  ```
+  </TabItem>
+</Tabs> 

--- a/docs/docs/commands/string/append.mdx
+++ b/docs/docs/commands/string/append.mdx
@@ -1,23 +1,24 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# SUBSTR
+# APPEND
 
 ### Syntax
 ```
-SUBSTR key start end
+APPEND key value
 ```
 
 ### Module
 <span className="acl-category">string</span>
 
 ### Categories 
-<span className="acl-category">read</span>
-<span className="acl-category">slow</span>
+<span className="acl-category">write</span>
+<span className="acl-category">fast</span>
 <span className="acl-category">string</span>
 
 ### Description 
-Return the substring of the string value stored at key. The substring is specified by the start and end indexes.
+Appends a value to the end of a string. If the doesn't exist, it creates the key with the value (acts as a SET).
+Returns the length of the string after the append operation.
 
 ### Examples
 
@@ -29,19 +30,19 @@ Return the substring of the string value stored at key. The substring is specifi
   ]}
 >
   <TabItem value="go">
-    Get the substring of a string value:
+    Append a value to the end of a string:
     ```go
     db, err := sugardb.NewSugarDB()
     if err != nil {
       log.Fatal(err)
     }
-    substring, err := db.GetRange("key", 4, 10)
+    len, err := db.Append("key", "value")
     ```
   </TabItem>
   <TabItem value="cli">
-    Get the substring of a string value:
+    Append a value to the end of a string:
     ```
-    > GETRANGE key 4 10
+    > APPEND "key" "value"
     ```
   </TabItem>
 </Tabs>  

--- a/docs/docs/commands/string/getrange.mdx
+++ b/docs/docs/commands/string/getrange.mdx
@@ -9,12 +9,12 @@ GETRANGE key start end
 ```
 
 ### Module
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Categories 
 <span className="acl-category">read</span>
 <span className="acl-category">slow</span>
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Description 
 Return the substring of the string value stored at key. The substring is specified by the start and end indexes.

--- a/docs/docs/commands/string/setrange.mdx
+++ b/docs/docs/commands/string/setrange.mdx
@@ -9,12 +9,12 @@ SETRANGE key offset value
 ```
 
 ### Module
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Categories 
 <span className="acl-category">write</span>
 <span className="acl-category">slow</span>
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Description 
 Overwrites part of a string value with another by offset. Creates the key if it doesn't exist.

--- a/docs/docs/commands/string/strlen.mdx
+++ b/docs/docs/commands/string/strlen.mdx
@@ -9,12 +9,12 @@ STRLEN key
 ```
 
 ### Module
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Categories 
 <span className="acl-category">fast</span>
 <span className="acl-category">read</span>
-<span className="acl-category">sortedset</span>
+<span className="acl-category">string</span>
 
 ### Description 
 Returns length of the key's value if it's a string.


### PR DESCRIPTION
I noticed some commands were not included in the docs, so I added them in this pr. 

The command docs I added:
- echo
- copy
- incrbyfloat
- randomkey
- append

I also made sure the README list was up to date. 