### PR TITLE
Added election timeout config option for raft 

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,14 +19,15 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/echovault/sugardb/internal"
-	"github.com/echovault/sugardb/internal/constants"
 	"log"
 	"os"
 	"path"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/echovault/sugardb/internal"
+	"github.com/echovault/sugardb/internal/constants"
 
 	"gopkg.in/yaml.v3"
 )
@@ -55,6 +56,7 @@ type Config struct {
 	EvictionPolicy    string        `json:"EvictionPolicy" yaml:"EvictionPolicy"`
 	EvictionSample    uint          `json:"EvictionSample" yaml:"EvictionSample"`
 	EvictionInterval  time.Duration `json:"EvictionInterval" yaml:"EvictionInterval"`
+	ElectionTimeout   time.Duration `json:"ElectionTimeout" yaml:"ElectionTimeout"`
 	Modules           []string      `json:"Plugins" yaml:"Plugins"`
 	DiscoveryPort     uint16        `json:"DiscoveryPort" yaml:"DiscoveryPort"`
 	RaftBindAddr      string
@@ -160,6 +162,7 @@ There is no limit by default.`, func(memory string) error {
 	restoreAOF := flag.Bool("restore-aof", false, "This flag prompts the echovault to restore state from append-only logs. Only works in standalone mode. Lower priority than restoreSnapshot.")
 	evictionSample := flag.Uint("eviction-sample", 20, "An integer specifying the number of keys to sample when checking for expired keys.")
 	evictionInterval := flag.Duration("eviction-interval", 100*time.Millisecond, "The interval between each sampling of keys to evict.")
+	electionTimeout := flag.Duration("election-timeout", 1000*time.Millisecond, "The maximum duration the leader will wait for followers to reach consensus on an election before starting a new election")
 	forwardCommand := flag.Bool(
 		"forward-commands",
 		false,
@@ -217,6 +220,7 @@ It is a plain text value by default but you can provide a SHA256 hash by adding 
 		EvictionPolicy:    evictionPolicy,
 		EvictionSample:    *evictionSample,
 		EvictionInterval:  *evictionInterval,
+		ElectionTimeout:   *electionTimeout,
 		Modules:           modules,
 		DiscoveryPort:     uint16(*discoveryPort),
 		RaftBindAddr:      raftBindAddr,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	EvictionSample    uint          `json:"EvictionSample" yaml:"EvictionSample"`
 	EvictionInterval  time.Duration `json:"EvictionInterval" yaml:"EvictionInterval"`
 	ElectionTimeout   time.Duration `json:"ElectionTimeout" yaml:"ElectionTimeout"`
+	HeartbeatTimeout  time.Duration `json:"HeartbeatTimeout" yaml:"HeartbeatTimeout"`
+	CommitTimeout     time.Duration `json:"CommitTimeout" yaml:"CommitTimeout"`
 	Modules           []string      `json:"Plugins" yaml:"Plugins"`
 	DiscoveryPort     uint16        `json:"DiscoveryPort" yaml:"DiscoveryPort"`
 	RaftBindAddr      string
@@ -163,6 +165,8 @@ There is no limit by default.`, func(memory string) error {
 	evictionSample := flag.Uint("eviction-sample", 20, "An integer specifying the number of keys to sample when checking for expired keys.")
 	evictionInterval := flag.Duration("eviction-interval", 100*time.Millisecond, "The interval between each sampling of keys to evict.")
 	electionTimeout := flag.Duration("election-timeout", 1000*time.Millisecond, "The maximum duration the leader will wait for followers to reach consensus on an election before starting a new election")
+	heartbeatTimeout := flag.Duration("heartbeat-timeout", 1000*time.Millisecond, "The interval between heartbeats sent by the leader to followers. In other words, the time in candidate state without leader contact.")
+	commitTimeout := flag.Duration("commit-timeout", 50*time.Millisecond, "The time the leader waits before sending a message to followers to confirm log entries are committed. May be delayed by up to 2x this value due to random staggering.")
 	forwardCommand := flag.Bool(
 		"forward-commands",
 		false,
@@ -221,6 +225,8 @@ It is a plain text value by default but you can provide a SHA256 hash by adding 
 		EvictionSample:    *evictionSample,
 		EvictionInterval:  *evictionInterval,
 		ElectionTimeout:   *electionTimeout,
+		HeartbeatTimeout:  *heartbeatTimeout,
+		CommitTimeout:     *commitTimeout,
 		Modules:           modules,
 		DiscoveryPort:     uint16(*discoveryPort),
 		RaftBindAddr:      raftBindAddr,

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -39,6 +39,8 @@ func DefaultConfig() Config {
 		EvictionSample:    20,
 		EvictionInterval:  100 * time.Millisecond,
 		ElectionTimeout:   1000 * time.Millisecond,
+		HeartbeatTimeout:  1000 * time.Millisecond,
+		CommitTimeout:     50 * time.Millisecond,
 		Modules:           make([]string, 0),
 	}
 }

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"time"
+
 	"github.com/echovault/sugardb/internal"
 	"github.com/echovault/sugardb/internal/constants"
-	"time"
 )
 
 func DefaultConfig() Config {
@@ -37,6 +38,7 @@ func DefaultConfig() Config {
 		EvictionPolicy:    constants.NoEviction,
 		EvictionSample:    20,
 		EvictionInterval:  100 * time.Millisecond,
+		ElectionTimeout:   1000 * time.Millisecond,
 		Modules:           make([]string, 0),
 	}
 }

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -64,6 +64,8 @@ func (r *Raft) RaftInit(ctx context.Context) {
 	raftConfig.SnapshotThreshold = conf.SnapShotThreshold
 	raftConfig.SnapshotInterval = conf.SnapshotInterval
 	raftConfig.ElectionTimeout = conf.ElectionTimeout
+	raftConfig.HeartbeatTimeout = conf.HeartbeatTimeout
+	raftConfig.CommitTimeout = conf.CommitTimeout
 
 	var logStore raft.LogStore
 	var stableStore raft.StableStore

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -18,14 +18,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/echovault/sugardb/internal"
-	"github.com/echovault/sugardb/internal/config"
-	"github.com/echovault/sugardb/internal/memberlist"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/echovault/sugardb/internal"
+	"github.com/echovault/sugardb/internal/config"
+	"github.com/echovault/sugardb/internal/memberlist"
 
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
@@ -62,6 +63,7 @@ func (r *Raft) RaftInit(ctx context.Context) {
 	raftConfig.LocalID = raft.ServerID(conf.ServerID)
 	raftConfig.SnapshotThreshold = conf.SnapShotThreshold
 	raftConfig.SnapshotInterval = conf.SnapshotInterval
+	raftConfig.ElectionTimeout = conf.ElectionTimeout
 
 	var logStore raft.LogStore
 	var stableStore raft.StableStore

--- a/sugardb/config.go
+++ b/sugardb/config.go
@@ -16,10 +16,11 @@ package sugardb
 
 import (
 	"context"
+	"time"
+
 	"github.com/echovault/sugardb/internal"
 	"github.com/echovault/sugardb/internal/config"
 	"github.com/echovault/sugardb/internal/constants"
-	"time"
 )
 
 // DefaultConfig returns the default configuration.
@@ -312,6 +313,15 @@ func WithEvictionSample(evictionSample uint) func(sugardb *SugarDB) {
 func WithEvictionInterval(evictionInterval time.Duration) func(sugardb *SugarDB) {
 	return func(sugardb *SugarDB) {
 		sugardb.config.EvictionInterval = evictionInterval
+	}
+}
+
+// WithElectionTimeout is an option to the NewSugarDB function that allows you to pass a
+// custom ElectionTimeout to SugarDB.
+// If not specified, SugarDB will use the default configuration from config.DefaultConfig().
+func WithElectionTimeout(electionTimeout time.Duration) func(sugardb *SugarDB) {
+	return func(sugardb *SugarDB) {
+		sugardb.config.ElectionTimeout = electionTimeout
 	}
 }
 

--- a/sugardb/config.go
+++ b/sugardb/config.go
@@ -325,6 +325,24 @@ func WithElectionTimeout(electionTimeout time.Duration) func(sugardb *SugarDB) {
 	}
 }
 
+// WithHeartbeatTimeout is an option to the NewSugarDB function that allows you to pass a
+// custom HeartbeatTimeout to SugarDB.
+// If not specified, SugarDB will use the default configuration from config.DefaultConfig().
+func WithHeartbeatTimeout(heartbeatTimeout time.Duration) func(sugardb *SugarDB) {
+	return func(sugardb *SugarDB) {
+		sugardb.config.HeartbeatTimeout = heartbeatTimeout
+	}
+}
+
+// WithHeartbeatTimeout is an option to the NewSugarDB function that allows you to pass a
+// custom HeartbeatTimeout to SugarDB.
+// If not specified, SugarDB will use the default configuration from config.DefaultConfig().
+func WithCommitTimeout(commitTimeout time.Duration) func(sugardb *SugarDB) {
+	return func(sugardb *SugarDB) {
+		sugardb.config.CommitTimeout = commitTimeout
+	}
+}
+
 // WithModules is an option to the NewSugarDB function that allows you to pass a
 // custom Modules to SugarDB.
 // If not specified, SugarDB will use the default configuration from config.DefaultConfig().


### PR DESCRIPTION
issue: https://github.com/EchoVault/SugarDB/issues/163 

Added [ElectionTimeout](https://github.com/hashicorp/raft/blob/8f99c150c37d3f7ded1c13f1f5f52b60374632b6/config.go#L291) - which specifies the amount of time to wait for quorum consensus during leader election before attempting the next one.

The default is [here](https://github.com/hashicorp/raft/blob/8f99c150c37d3f7ded1c13f1f5f52b60374632b6/config.go#L320), which I added in SugarDB's default config. 

Question: maybe we can also expose the `HeartbeatTimeout` also?